### PR TITLE
fix: concept video resize in mobile

### DIFF
--- a/src/shared/components/video-modal/VideoModal.js
+++ b/src/shared/components/video-modal/VideoModal.js
@@ -9,7 +9,6 @@ const VideoModal = ({ showing, src, onClick }) => (
         <iframe
             ref={ setRef }
             className={ classNames(showing ? styles.video : styles.hidden) }
-            width="560" height="315"
             src={ `${src}?enablejsapi=1` }
             frameBorder="0"
             allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"

--- a/src/shared/components/video-modal/VideoModal.module.css
+++ b/src/shared/components/video-modal/VideoModal.module.css
@@ -33,9 +33,18 @@
     right: 0;
     bottom: 0;
     left: 0;
+    width: 560px;
+    height: 315px;
     margin: auto;
 }
 
 .hidden {
     display: none;
+}
+
+@media(width <= 600px) {
+    .video {
+        width: 300px;
+        height: 168.75px;
+    }
 }


### PR DESCRIPTION
There was a problem with the video at lower resolutions, it is now being resized to fit in the viewport.